### PR TITLE
Fix/task#99 is staff rbac bypass

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -23,8 +23,13 @@ from rest_framework.views import APIView
 from common.utils import EchoBuffer
 
 from .models import AuditLog, User, UserStatusLog
-from .permissions import HasRBACPermission, IsSystemAdmin
-from .rbac import PERMISSION_USERS_CREATE, PERMISSION_USERS_MANAGE_ROLES
+from .permissions import HasRBACPermission, IsSystemAdmin, user_has_permission
+from .rbac import (
+    PERMISSION_AUDIT_LOGS_VIEW_ALL,
+    PERMISSION_AUDIT_LOGS_VIEW_OWN,
+    PERMISSION_USERS_CREATE,
+    PERMISSION_USERS_MANAGE_ROLES,
+)
 from .serializers import (
     AuditLogSerializer,
     ChangePasswordSerializer,
@@ -132,12 +137,15 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        if user.is_staff or user.is_superuser:
+        if user_has_permission(user, PERMISSION_AUDIT_LOGS_VIEW_ALL):
             return AuditLog.objects.all().select_related("actor", "target_user")
 
-        return AuditLog.objects.filter(
-            Q(actor=user) | Q(target_user=user)
-        ).select_related("actor", "target_user")
+        if user_has_permission(user, PERMISSION_AUDIT_LOGS_VIEW_OWN):
+            return AuditLog.objects.filter(
+                Q(actor=user) | Q(target_user=user)
+            ).select_related("actor", "target_user")
+
+        return AuditLog.objects.none()
 
     @action(
         detail=False,

--- a/drones/permissions.py
+++ b/drones/permissions.py
@@ -18,9 +18,6 @@ class DronePermission(BasePermission):
         if not user or not user.is_authenticated:
             return False
 
-        if getattr(user, "is_staff", False):
-            return True
-
         return user_has_permission(user, permission_code)
 
     def _get_requested_status(self, request):

--- a/repairs/permissions.py
+++ b/repairs/permissions.py
@@ -11,9 +11,6 @@ class RepairPermission(BasePermission):
         if not user or not user.is_authenticated:
             return False
 
-        if getattr(user, "is_staff", False):
-            return True
-
         return user_has_permission(user, permission_code)
 
     def has_permission(self, request, view):


### PR DESCRIPTION
## Summary
`is_staff` / `is_superuser` bypassed the RBAC matrix in three places, granting
elevated API access independent of a user's assigned role.

## Fixes
- **drones/permissions.py** & **repairs/permissions.py** — removed the
  `if user.is_staff: return True` short-circuit in `_has_permission()`.
  Drone/Repair API authorization now depends solely on the RBAC matrix.
- **accounts/views.py** (`AuditLogViewSet`) — replaced the
  `if user.is_staff or user.is_superuser` check with the RBAC permissions
  `audit_logs.view_all` / `audit_logs.view_own` (previously defined but never
  enforced). Users with neither now get an empty queryset instead of falling
  back to their own logs.