### PR TITLE
Fix mission read RBAC bypass

### DIFF
--- a/missions/tests.py
+++ b/missions/tests.py
@@ -5,7 +5,9 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from accounts.models import User
 from drones.models import Drone, DroneStatusHistory, WriteOffRecord
+from roles.models import TECHNICIAN_CODE, Role
 
 from .factories import (
     AdminUserFactory,
@@ -575,6 +577,27 @@ def _future_datetime(hours=1):
     return timezone.now() + timedelta(hours=hours)
 
 
+def _create_technician_user():
+    technician_role, _ = Role.objects.get_or_create(
+        code=TECHNICIAN_CODE,
+        defaults={"name": "Technician"},
+    )
+    return User.objects.create_user(
+        username="technician_user",
+        email="technician_user@example.com",
+        password="password",
+        role=technician_role,
+    )
+
+
+def _create_user_without_role():
+    return User.objects.create_user(
+        username="user_without_role",
+        email="user_without_role@example.com",
+        password="password",
+    )
+
+
 class MissionCreateTests(APITestCase):
     """POST /api/missions/ — create endpoint, validation, permissions."""
 
@@ -766,6 +789,8 @@ class MissionListTests(APITestCase):
     def setUp(self):
         self.dispatcher = DispatcherUserFactory()
         self.viewer = ViewerUserFactory()
+        self.technician = _create_technician_user()
+        self.user_without_role = _create_user_without_role()
 
         self.url = reverse("missions:mission-list-create")
 
@@ -855,6 +880,18 @@ class MissionListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["results"]), 3)
 
+    def test_technician_without_missions_view_cannot_list(self):
+        MissionFactory()
+        self.client.force_authenticate(self.technician)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_without_role_cannot_list(self):
+        MissionFactory()
+        self.client.force_authenticate(self.user_without_role)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
 
 class MissionDetailTests(APITestCase):
     """GET /api/missions/{id}/ — retrieve detail."""
@@ -862,6 +899,8 @@ class MissionDetailTests(APITestCase):
     def setUp(self):
         self.viewer = ViewerUserFactory()
         self.mission = MissionFactory(title="Detail Mission")
+        self.technician = _create_technician_user()
+        self.user_without_role = _create_user_without_role()
 
         self.url = reverse(
             "missions:mission-detail",
@@ -890,3 +929,13 @@ class MissionDetailTests(APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_technician_without_missions_view_cannot_retrieve(self):
+        self.client.force_authenticate(self.technician)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_without_role_cannot_retrieve(self):
+        self.client.force_authenticate(self.user_without_role)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/missions/views.py
+++ b/missions/views.py
@@ -8,6 +8,7 @@ from accounts.rbac import (
     PERMISSION_MISSIONS_RECORD_CONDITION,
     PERMISSION_MISSIONS_RECORD_OUTCOME,
     PERMISSION_MISSIONS_UPDATE_STATUS,
+    PERMISSION_MISSIONS_VIEW,
 )
 
 from .models import Mission, MissionAuditLog, MissionDrone, Status
@@ -38,6 +39,10 @@ class MissionsRecordConditionRBAC(HasRBACPermission):
     required_permission = PERMISSION_MISSIONS_RECORD_CONDITION
 
 
+class MissionsViewRBAC(HasRBACPermission):
+    required_permission = PERMISSION_MISSIONS_VIEW
+
+
 class MissionPagination(PageNumberPagination):
     page_size = 10
     page_size_query_param = "page_size"
@@ -46,7 +51,11 @@ class MissionPagination(PageNumberPagination):
 
 class MissionListCreateView(generics.ListCreateAPIView):
     serializer_class = MissionSerializer
-    permission_classes = [permissions.IsAuthenticated, IsDispatcherOrAdmin]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        MissionsViewRBAC,
+        IsDispatcherOrAdmin,
+    ]
     pagination_class = MissionPagination
 
     def get_queryset(self):
@@ -85,7 +94,7 @@ class MissionListCreateView(generics.ListCreateAPIView):
 
 class MissionDetailView(generics.RetrieveAPIView):
     serializer_class = MissionSerializer
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, MissionsViewRBAC]
     queryset = Mission.objects.with_related()
 
 
@@ -148,7 +157,11 @@ class MissionStatusUpdateView(generics.RetrieveUpdateAPIView):
 
 class MissionAssignmentListCreateView(generics.ListCreateAPIView):
     serializer_class = MissionDroneSerializer
-    permission_classes = [permissions.IsAuthenticated, IsDispatcherOrAdmin]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        MissionsViewRBAC,
+        IsDispatcherOrAdmin,
+    ]
 
     def get_mission(self):
         if not hasattr(self, "_mission"):


### PR DESCRIPTION
### Summary

Fixed RBAC bypass for mission read endpoints.

* Added `missions.view` permission check for mission list/detail access
* Prevented Technician and users without a role from reading mission data
* Added regression tests for unauthorized mission read access
